### PR TITLE
Dependabot 設定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "cargo"
+    directory: "/src-tauri"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## 概要
- Dependabot の設定ファイルを追加しました

## 変更内容
- dependabot.yml を新規追加
- 以下の依存関係を週次で更新するよう設定
  - npm (/)
  - cargo (/src-tauri)
  - github-actions (/)
- 各エコシステムの同時オープン PR 数を 10 に設定

## 期待する効果
- 依存関係の更新を継続的に自動化できる
- セキュリティアップデートの取り込みを早められる