### PR TITLE
fix: SGF読み込みの堅牢性を改善

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -286,6 +286,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chardetng"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +665,15 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -1093,6 +1113,8 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 name = "go-kifu-viewer"
 version = "0.1.1"
 dependencies = [
+ "chardetng",
+ "encoding_rs",
  "filetime",
  "rfd",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,8 @@ tauri = { version = "2", features = [] }
 thiserror = "2"
 rfd = "0.17"
 filetime = "0.2"
+chardetng = "0.1"
+encoding_rs = "0.8"
 
 [features]
 default = ["custom-protocol"]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,5 +1,7 @@
 use crate::sgf::parser::parse_sgf_collection;
 use crate::sgf::types::SgfCollection;
+use chardetng::EncodingDetector;
+use encoding_rs::UTF_8;
 use filetime::{set_file_mtime, FileTime};
 use rfd::FileDialog;
 use std::fs;
@@ -41,8 +43,26 @@ pub fn pick_save_sgf_file() -> Result<Option<String>, String> {
 
 #[tauri::command]
 pub fn open_sgf_file(path: String) -> Result<SgfCollection, String> {
-    let content = fs::read_to_string(&path).map_err(|e| format!("failed to read file: {e}"))?;
+    let bytes = fs::read(&path).map_err(|e| format!("failed to read file: {e}"))?;
+    let content = decode_sgf_bytes(&bytes);
     parse_sgf_collection(&content).map_err(|e| e.to_string())
+}
+
+fn decode_sgf_bytes(bytes: &[u8]) -> String {
+    if let Ok(utf8) = std::str::from_utf8(bytes) {
+        return utf8.strip_prefix('\u{feff}').unwrap_or(utf8).to_string();
+    }
+
+    let mut detector = EncodingDetector::new();
+    detector.feed(bytes, true);
+    let encoding = detector.guess(None, true);
+    let (decoded, _, _) = encoding.decode(bytes);
+
+    if encoding == UTF_8 {
+        decoded.strip_prefix('\u{feff}').unwrap_or(&decoded).to_string()
+    } else {
+        decoded.into_owned()
+    }
 }
 
 #[tauri::command]
@@ -67,4 +87,25 @@ pub fn take_pending_open_path() -> Option<String> {
         return pending.take();
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode_sgf_bytes;
+
+    #[test]
+    fn decode_sgf_bytes_supports_utf8_bom() {
+        let bytes = b"\xEF\xBB\xBF(;GM[1]FF[4]SZ[19])";
+        let decoded = decode_sgf_bytes(bytes);
+        assert_eq!(decoded, "(;GM[1]FF[4]SZ[19])");
+    }
+
+    #[test]
+    fn decode_sgf_bytes_recovers_invalid_utf8() {
+        let bytes = b"(;GM[1]FF[4]C[abc\xFFdef])";
+        let decoded = decode_sgf_bytes(bytes);
+        assert!(decoded.starts_with("(;GM[1]FF[4]C["));
+        assert!(decoded.contains("abc"));
+        assert!(decoded.contains("def"));
+    }
 }

--- a/src-tauri/src/sgf/parser.rs
+++ b/src-tauri/src/sgf/parser.rs
@@ -19,6 +19,15 @@ pub fn parse_sgf_collection(input: &str) -> Result<SgfCollection, ParseError> {
 
     p.skip_ws();
     while !p.is_eof() {
+        if !matches!(p.peek(), Some('(')) {
+            if games.is_empty() {
+                return Err(ParseError::Expected {
+                    expected: '(',
+                    at: p.idx,
+                });
+            }
+            break;
+        }
         games.push(p.parse_game_tree()?);
         p.skip_ws();
     }
@@ -97,9 +106,18 @@ impl Parser {
     fn parse_node_sequence(&mut self) -> Result<Vec<SgfNode>, ParseError> {
         let mut nodes = Vec::new();
         self.skip_ws();
-        while matches!(self.peek(), Some(';')) {
-            nodes.push(self.parse_node()?);
+        if matches!(self.peek(), Some(';')) {
+            while matches!(self.peek(), Some(';')) {
+                nodes.push(self.parse_node()?);
+                self.skip_ws();
+            }
+        } else if matches!(self.peek(), Some(c) if c.is_ascii_uppercase()) {
+            nodes.push(self.parse_implicit_root_node()?);
             self.skip_ws();
+            while matches!(self.peek(), Some(';')) {
+                nodes.push(self.parse_node()?);
+                self.skip_ws();
+            }
         }
 
         if nodes.is_empty() {
@@ -129,6 +147,24 @@ impl Parser {
             self.skip_ws();
         }
 
+        Ok(node)
+    }
+
+    fn parse_implicit_root_node(&mut self) -> Result<SgfNode, ParseError> {
+        let mut node = SgfNode::empty();
+        while let Some(c) = self.peek() {
+            if c == ';' || c == '(' || c == ')' {
+                break;
+            }
+            if c.is_whitespace() {
+                self.skip_ws();
+                continue;
+            }
+            let ident = self.parse_ident()?;
+            let values = self.parse_values()?;
+            node.properties.push(SgfProperty { ident, values });
+            self.skip_ws();
+        }
         Ok(node)
     }
 
@@ -216,5 +252,22 @@ mod tests {
         let root = &parsed.games[0].root;
         assert_eq!(root.properties[0].ident, "B");
         assert_eq!(root.children.len(), 2);
+    }
+
+    #[test]
+    fn parse_without_leading_root_semicolon() {
+        let sgf = "(FF[4]SZ[19];B[pd];W[dd])";
+        let parsed = parse_sgf_collection(sgf).expect("parse should succeed");
+        let root = &parsed.games[0].root;
+        assert_eq!(root.properties[0].ident, "FF");
+        assert_eq!(root.children.len(), 1);
+    }
+
+    #[test]
+    fn parse_with_trailing_non_sgf_text() {
+        let sgf = "(;FF[4]SZ[19];B[pd];W[dd])\n# trailing notes\nline2: metadata";
+        let parsed = parse_sgf_collection(sgf).expect("parse should succeed");
+        assert_eq!(parsed.games.len(), 1);
+        assert_eq!(parsed.games[0].root.properties[0].ident, "FF");
     }
 }


### PR DESCRIPTION
## 概要
- UTF-8 固定の read_to_string をやめ、バイト列から文字コード推定して SGF をデコードするように変更
- ルートノード先頭のセミコロンが省略された SGF でも、暗黙ルートとして解釈できるように変更
- 1局の SGF 本体の後ろに非SGFテキストが続く場合、追加ゲーム木として解釈せず読み込みを終了するように変更
- BOM 対応、無効 UTF-8 復旧、暗黙ルート、末尾ノイズ許容の回帰テストを追加

## テスト
- mise x rust@stable -- cargo test

Closes #24