### PR TITLE
RDに設定された日付をDTとして読み込めるようにする

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,7 +8,7 @@
   import logoKifu from "./lib/assets/logo-kifu.svg";
   import { setupMoveSound } from "./lib/audio/moveSound";
   import { openSgfFile, pickSaveSgfFile, pickSgfFile, saveSgfTextFile, takePendingOpenPath } from "./lib/tauri/commands";
-  import { normalizeCollectionForSave } from "./lib/sgf/normalize";
+  import { normalizeCollectionForLoad, normalizeCollectionForSave } from "./lib/sgf/normalize";
   import { serializeSgfCollection } from "./lib/sgf/serializer";
   import { canonicalSgf, createEmptyCollection, currentFilePath, ensureCollection, isDirty, setCollection } from "./lib/stores/sgf";
   import { goToStart } from "./lib/stores/playback";
@@ -25,7 +25,7 @@
   const openFromPath = async (path: string) => {
     try {
       const loaded = await openSgfFile(path);
-      setCollection(loaded);
+      setCollection(normalizeCollectionForLoad(loaded));
       currentFilePath.set(path);
       openedName = basename(path);
       goToStart();

--- a/src/lib/sgf/normalize.ts
+++ b/src/lib/sgf/normalize.ts
@@ -33,6 +33,33 @@ const normalizeRootProperties = (properties: SgfProperty[]): SgfProperty[] => {
   return [...kept, { ident: APP_PROPERTY.ident, values: [...APP_PROPERTY.values] }];
 };
 
+const normalizeRootPropertiesForLoad = (properties: SgfProperty[]): SgfProperty[] => {
+  const normalized: SgfProperty[] = [];
+  let firstDtValue = "";
+  let firstRdValue = "";
+
+  for (const prop of properties) {
+    if (prop.ident === "RD") {
+      if (firstRdValue === "") {
+        firstRdValue = prop.values[0] ?? "";
+      }
+      continue;
+    }
+
+    normalized.push({ ident: prop.ident, values: [...prop.values] });
+
+    if (prop.ident === "DT" && firstDtValue === "") {
+      firstDtValue = prop.values[0] ?? "";
+    }
+  }
+
+  if (firstDtValue === "" && firstRdValue !== "") {
+    normalized.push({ ident: "DT", values: [firstRdValue] });
+  }
+
+  return normalized;
+};
+
 const normalizeNode = (node: SgfNode, isRoot: boolean): SgfNode => {
   return {
     properties: isRoot ? normalizeRootProperties(node.properties) : keepAllowedProperties(node.properties, NODE_ALLOWED_IDENTS),
@@ -44,6 +71,17 @@ export const normalizeCollectionForSave = (collection: SgfCollection): SgfCollec
   return {
     games: collection.games.map((game) => ({
       root: normalizeNode(game.root, true)
+    }))
+  };
+};
+
+export const normalizeCollectionForLoad = (collection: SgfCollection): SgfCollection => {
+  return {
+    games: collection.games.map((game) => ({
+      root: {
+        properties: normalizeRootPropertiesForLoad(game.root.properties),
+        children: game.root.children
+      }
     }))
   };
 };


### PR DESCRIPTION
## 概要
Issue #25 の対応です。RD に日付が設定されている棋譜を読み込んだ際、日付欄へ正しく反映されるようにしました。

## 変更内容
- 読み込み時の正規化処理 normalizeCollectionForLoad を追加
- ルートプロパティで DT が未設定かつ RD が設定済みの場合、DT に RD の値を補完
- 読み込み時に RD は除去し、DT がある場合は DT を優先
- SGFオープン時に読み込み正規化を適用

## 期待される動作
- RD のみ設定された棋譜でも、日付入力欄に日付が表示される
- DT と RD の両方がある場合は DT が使われる
- 保存時には DT が出力され、RD は出力されない

Closes #25