### PR TITLE
名前を付けて保存時に元ファイル名とディレクトリを既定値にする

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -31,12 +31,21 @@ pub fn pick_sgf_file() -> Result<Option<String>, String> {
 }
 
 #[tauri::command]
-pub fn pick_save_sgf_file() -> Result<Option<String>, String> {
-    let file = FileDialog::new()
+pub fn pick_save_sgf_file(
+    default_file_name: Option<String>,
+    default_directory: Option<String>,
+) -> Result<Option<String>, String> {
+    let file_name = default_file_name
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or_else(|| "game.sgf".to_string());
+    let mut dialog = FileDialog::new()
         .add_filter("SGF", &["sgf"])
         .set_title("Save SGF file")
-        .set_file_name("game.sgf")
-        .save_file();
+        .set_file_name(&file_name);
+    if let Some(dir) = default_directory.filter(|dir| !dir.trim().is_empty()) {
+        dialog = dialog.set_directory(dir);
+    }
+    let file = dialog.save_file();
 
     Ok(file.map(|p| p.to_string_lossy().to_string()))
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -21,6 +21,21 @@
   const basename = (path: string): string => {
     return path.split(/[\\/]/).pop() ?? path;
   };
+  const dirname = (path: string): string => {
+    const index = path.lastIndexOf("/");
+    const windowsIndex = path.lastIndexOf("\\");
+    const splitAt = Math.max(index, windowsIndex);
+    if (splitAt < 0) {
+      return "";
+    }
+    if (splitAt === 0) {
+      return path[0];
+    }
+    if (splitAt === 2 && path[1] === ":" && path[2] === "\\") {
+      return path.slice(0, 3);
+    }
+    return path.slice(0, splitAt);
+  };
 
   const openFromPath = async (path: string) => {
     try {
@@ -63,7 +78,7 @@
       const sgfText = serializeSgfCollection(normalized);
       let savePath = $currentFilePath;
       if (!savePath) {
-        const picked = await pickSaveSgfFile();
+        const picked = await pickSaveSgfFile(openedName || undefined, dirname($currentFilePath));
         if (!picked) {
           return;
         }
@@ -85,7 +100,7 @@
       const collection = ensureCollection();
       const normalized = normalizeCollectionForSave(collection);
       const sgfText = serializeSgfCollection(normalized);
-      const savePath = await pickSaveSgfFile();
+      const savePath = await pickSaveSgfFile(openedName || undefined, dirname($currentFilePath));
       if (!savePath) {
         return;
       }

--- a/src/lib/tauri/commands.ts
+++ b/src/lib/tauri/commands.ts
@@ -5,8 +5,8 @@ export const pickSgfFile = async (): Promise<string | null> => {
   return invoke<string | null>("pick_sgf_file");
 };
 
-export const pickSaveSgfFile = async (): Promise<string | null> => {
-  return invoke<string | null>("pick_save_sgf_file");
+export const pickSaveSgfFile = async (defaultFileName?: string, defaultDirectory?: string): Promise<string | null> => {
+  return invoke<string | null>("pick_save_sgf_file", { defaultFileName, defaultDirectory });
 };
 
 export const openSgfFile = async (path: string): Promise<SgfCollection> => {


### PR DESCRIPTION
## 概要
- 既存ファイルを開いた状態で「名前を付けて保存」したとき、既定ファイル名に開いているファイル名を利用するように変更しました
- 同時に、保存ダイアログの初期ディレクトリとして開いているファイルの親ディレクトリを渡すようにしました
- 既定値が取得できない場合は従来どおり game.sgf をフォールバックで利用します

## 変更内容
- Tauri コマンド pick_save_sgf_file に default_file_name / default_directory 引数を追加
- フロントエンドの pickSaveSgfFile 呼び出しに既定ファイル名・既定ディレクトリを渡す処理を追加
- App.svelte に親ディレクトリ算出処理を追加

## 確認
- npm run check
- mise x rust@stable -- cargo test -q

Closes #23