### PR TITLE
[codex] CI の npm 固定（11.10.0）を追加

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -32,6 +32,9 @@ jobs:
           node-version: 24.13.0
           cache: npm
 
+      - name: Use npm 11.10.0
+        run: npm i -g npm@11.10.0
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
           node-version: 24.13.0
           cache: npm
 
+      - name: Use npm 11.10.0
+        run: npm i -g npm@11.10.0
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## 概要
- actions/setup-node の直後に npm 11.10.0 を固定するステップを追加
- npm を利用する workflow に適用

## 目的
- min-release-age を利用できる npm バージョンを CI で安定して使うため